### PR TITLE
Add silent flag to avoid console output when your logging to a file a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ optional arguments:
                         HTLC stream output file; default htlc-stream.json
   --stream-mode STREAMMODE
                         If flagged no file will be written only streamed to stdout; default: false
+  --silent SILENT
+                        If flagged will not output to stdout; default: false
 ```
 
 ### Example output

--- a/stream-lnd-htlcs.py
+++ b/stream-lnd-htlcs.py
@@ -16,16 +16,21 @@ def main():
     arg_parser.add_argument(
         "--stream-mode", default="false", dest="streammode", help="Stream output to stdout only; default false",
     )
+    arg_parser.add_argument(
+        "--silent", default="false", dest="silent", help="Disable stdout output; default false",
+    )
+
     args = arg_parser.parse_args()
 
     lnd = Lnd(args.lnddir)
 
     for response in lnd.get_htlc_events():
         htlc = Htlc(lnd, response)
-        print(htlc.__dict__)
+        if args.silent == "false":
+            print(htlc.__dict__)
         if args.streammode == "false":
             with open(args.outfile, 'a') as f:
-                 print(htlc.__dict__, file=f)
+                print(htlc.__dict__, file=f)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add silent flag to avoid console output when your logging to a file and want to run in background