### PR TITLE
Output valid json

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ optional arguments:
 ### Example output
 
 ```
-{'incoming_channel': 'LN-node1-alias', 'outgoing_channel': 'LN-node2-alias', 'outgoing_channel_capacity': 5000000, 'outgoing_channel_remote_balance': 2500000, 'outgoing_channel_local_balance': 2500000, 'timestamp': 1626750720, 'event_type': 'SEND', 'event_outcome': 'forward_fail_event'}
+{"incoming_channel": "LN-node1-alias", "outgoing_channel": "LN-node2-alias", "outgoing_channel_capacity": 5000000, "outgoing_channel_remote_balance": 2500000, "outgoing_channel_local_balance": 2500000, "timestamp": 1626750720, "event_type": "SEND", "event_outcome": "forward_fail_event"}
 ...
-{'incoming_channel': 'LN-nodeX-alias', 'incoming_channel_capacity': 5000000, 'incoming_channel_remote_balance': 2500000, 'incoming_channel_local_balance': 7500000, 'outgoing_channel': 'LN-nodeY-alias', 'outgoing_channel_capacity': 10000000, 'outgoing_channel_remote_balance': 5000000, 'outgoing_channel_local_balance': 5000000, 'timestamp': 1626751932, 'event_type': 'FORWARD', 'event_outcome': 'settle_event'}
+{"incoming_channel": "LN-nodeX-alias", "incoming_channel_capacity": 5000000, "incoming_channel_remote_balance": 2500000, "incoming_channel_local_balance": 7500000, "outgoing_channel": "LN-nodeY-alias", "outgoing_channel_capacity": 10000000, "outgoing_channel_remote_balance": 5000000, "outgoing_channel_local_balance": 5000000, "timestamp": 1626751932, "event_type": "FORWARD", "event_outcome": "settle_event"}
 ```

--- a/stream-lnd-htlcs.py
+++ b/stream-lnd-htlcs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import json
 from lnd import Lnd
 from htlc import Htlc
 
@@ -27,11 +28,12 @@ def main():
 
     for response in lnd.get_htlc_events():
         htlc = Htlc(lnd, response, args.humandates)
+        htlc_json = json.dumps(htlc.__dict__)
         if args.silent == "false":
-            print(htlc.__dict__)
+            print(htlc_json)
         if args.streammode == "false":
             with open(args.outfile, 'a') as f:
-                print(htlc.__dict__, file=f)
+                print(htlc_json, file=f)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Output valid json, e.g. using double quotes and escaping backslashes, to make further processing of the results easier.

I've opted to also parse stdout output to valid json. If there are existing users filtering stdout using grep they probably would need to switch from `... | grep "'event_type': 'FORWARD'"` to something like `... | grep "\"event_type\": \"FORWARD\""` (escaping the new double quotes).

This might be a bit bothersome, but I think it would be more confusing if there's a difference between the stdout and file output.