### PR TITLE
Output channel ids as strings to avoid being changed by jq

### DIFF
--- a/htlc.py
+++ b/htlc.py
@@ -1,4 +1,5 @@
 from lnd_grpc import router_pb2 as lnrouter
+from lnd_grpc import rpc_pb2 as lnrpc
 from lnd import Lnd
 
 
@@ -23,7 +24,7 @@ class Htlc:
         self.event_outcome = self.get_enum_name_from_value(htlc.DESCRIPTOR.fields_by_name.items(), htlc.ListFields()[-1][0].number)
 
         if self.event_outcome == 'link_fail_event':
-            self.wire_failure = self.get_enum_name_from_value(lnrouter.FailureDetail.items(), htlc.link_fail_event.wire_failure)
+            self.wire_failure = self.get_enum_name_from_value(lnrpc.Failure.FailureCode.items(), htlc.link_fail_event.wire_failure)
             self.failure_detail = self.get_enum_name_from_value(lnrouter.FailureDetail.items(), htlc.link_fail_event.failure_detail)
             self.failure_string = htlc.link_fail_event.failure_string
             self.event_outcome_info = self.get_event_info_enum_names_from_values(htlc.link_fail_event)

--- a/htlc.py
+++ b/htlc.py
@@ -7,7 +7,7 @@ class Htlc:
     def __init__(self, lnd, htlc, humandates):
         if getattr(htlc, 'incoming_channel_id') != 0:
             self.incoming_htlc_id = htlc.incoming_htlc_id
-            self.incoming_channel_id = htlc.incoming_channel_id
+            self.incoming_channel_id = str(htlc.incoming_channel_id)
             self.incoming_peer = lnd.get_alias_from_channel_id(htlc.incoming_channel_id)
             self.incoming_channel_capacity = lnd.get_channel_capacity(htlc.incoming_channel_id)
             self.incoming_channel_remote_balance = lnd.get_channel_remote_balance(htlc.incoming_channel_id)
@@ -16,7 +16,7 @@ class Htlc:
             self.incoming_channel = lnd.get_own_alias()
         if getattr(htlc, 'outgoing_channel_id') != 0:
             self.outgoing_htlc_id = htlc.outgoing_htlc_id
-            self.outgoing_channel_id = htlc.outgoing_channel_id
+            self.outgoing_channel_id = str(htlc.outgoing_channel_id)
             self.outgoing_peer = lnd.get_alias_from_channel_id(htlc.outgoing_channel_id)
             self.outgoing_channel_capacity = lnd.get_channel_capacity(htlc.outgoing_channel_id)
             self.outgoing_channel_remote_balance = lnd.get_channel_remote_balance(htlc.outgoing_channel_id)

--- a/htlc.py
+++ b/htlc.py
@@ -22,12 +22,12 @@ class Htlc:
         self.event_type = self.get_enum_name_from_value(htlc.EventType.items(), htlc.event_type)
         self.event_outcome = self.get_enum_name_from_value(htlc.DESCRIPTOR.fields_by_name.items(), htlc.ListFields()[-1][0].number)
 
-        if self.event_outcome is 'link_fail_event':
+        if self.event_outcome == 'link_fail_event':
             self.wire_failure = self.get_enum_name_from_value(lnrouter.FailureDetail.items(), htlc.link_fail_event.wire_failure)
             self.failure_detail = self.get_enum_name_from_value(lnrouter.FailureDetail.items(), htlc.link_fail_event.failure_detail)
             self.failure_string = htlc.link_fail_event.failure_string
             self.event_outcome_info = self.get_event_info_enum_names_from_values(htlc.link_fail_event)
-        elif self.event_outcome is 'forward_event':
+        elif self.event_outcome == 'forward_event':
             self.event_outcome_info = self.get_event_info_enum_names_from_values(htlc.forward_event)
 
 


### PR DESCRIPTION
When passing the output through jq, the channel ids get rounded to the nearest 100. Changing the output to strings to avoid this.